### PR TITLE
Phase 2: Architecture refactoring

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -15,7 +15,6 @@ pub struct App {
     pub original_pw: String,
     pub pw: String,
     pub rpw: String,
-    pub selected_button: usize,
     pub users: StatefulList<String>,
     pub selected_items: Vec<bool>,
     pub help_items: StatefulList<String>,
@@ -82,7 +81,6 @@ impl App {
             original_pw: String::new(),
             pw: String::new(),
             rpw: String::new(),
-            selected_button: 0,
             users: StatefulList::with_items(Vec::new()),
             selected_items: Vec::new(),
             help_items: StatefulList::with_items(vec![

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -8,20 +8,9 @@ pub struct App {
     pub popup: bool,
     pub scroll_state: usize,
     pub current_dir: PathBuf,
-    pub export_path: String,
-    pub uid: String,
-    pub validity: String,
-    pub cipher: String,
-    pub original_pw: String,
-    pub pw: String,
-    pub rpw: String,
-    pub users: StatefulList<String>,
-    pub selected_items: Vec<bool>,
     pub help_items: StatefulList<String>,
     pub help_descriptions: HashMap<String, String>,
     pub help_active: bool,
-    pub revocation_reason: String,
-    pub revocation_path: String,
 }
 
 impl App {
@@ -74,15 +63,6 @@ impl App {
             popup: false,
             scroll_state: 0,
             current_dir,
-            export_path: String::new(),
-            uid: String::new(),
-            validity: String::new(),
-            cipher: String::new(),
-            original_pw: String::new(),
-            pw: String::new(),
-            rpw: String::new(),
-            users: StatefulList::with_items(Vec::new()),
-            selected_items: Vec::new(),
             help_items: StatefulList::with_items(vec![
                 "- h/Esc: Show/hide this help".to_string(),
                 "- q: Quit".to_string(),
@@ -100,8 +80,6 @@ impl App {
             ]),
             help_descriptions,
             help_active: false,
-            revocation_reason: String::new(),
-            revocation_path: String::new(),
         }
     }
 }

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -142,30 +142,20 @@ pub fn run_app(
                     }
 
                     // generate a new keypair (secret + revocation certificate)
-                    KeyCode::Char('g') => {
-                        match generate_keypair_tui(
-                            &manager,
-                            terminal,
-                            &mut app.uid,
-                            &mut app.validity,
-                            &mut app.cipher,
-                            &mut app.pw,
-                            &mut app.rpw,
-                        ) {
-                            Ok(()) => {
-                                show_input_popup(terminal, "Key pair generated successfully.")?;
-                                app.items = StatefulList::with_items(list_directory_contents(
-                                    &app.current_dir,
-                                )?);
-                            }
-                            Err(e) => {
-                                show_input_popup(
-                                    terminal,
-                                    &format!("Error generating key pair: {}", e),
-                                )?;
-                            }
+                    KeyCode::Char('g') => match generate_keypair_tui(&manager, terminal) {
+                        Ok(()) => {
+                            show_input_popup(terminal, "Key pair generated successfully.")?;
+                            app.items = StatefulList::with_items(list_directory_contents(
+                                &app.current_dir,
+                            )?);
                         }
-                    }
+                        Err(e) => {
+                            show_input_popup(
+                                terminal,
+                                &format!("Error generating key pair: {}", e),
+                            )?;
+                        }
+                    },
                     // export certificate from keypair
                     KeyCode::Char('e') => {
                         if let Some(cert_path) = app.items.selected() {
@@ -176,7 +166,6 @@ pub fn run_app(
                                         &manager,
                                         terminal,
                                         &cert_path.to_string_lossy(),
-                                        &mut app.export_path,
                                     ) {
                                         Ok(()) => {
                                             show_input_popup(
@@ -205,9 +194,6 @@ pub fn run_app(
                                         &manager,
                                         terminal,
                                         &cert_path.to_string_lossy(),
-                                        &mut app.original_pw,
-                                        &mut app.pw,
-                                        &mut app.rpw,
                                     ) {
                                         Ok(()) => {
                                             show_input_popup(
@@ -236,8 +222,6 @@ pub fn run_app(
                                         &manager,
                                         terminal,
                                         &cert_path.to_string_lossy(),
-                                        &mut app.original_pw,
-                                        &mut app.validity,
                                     ) {
                                         Ok(()) => {
                                             show_input_popup(
@@ -266,8 +250,6 @@ pub fn run_app(
                                         &manager,
                                         terminal,
                                         &cert_path.to_string_lossy(),
-                                        &mut app.original_pw,
-                                        &mut app.uid,
                                     ) {
                                         Ok(()) => {
                                             show_input_popup(
@@ -293,14 +275,12 @@ pub fn run_app(
                             match check_certificate(cert_path) {
                                 CertificateType::Cert(_) => {
                                     let user_emails = extract_users_from_certificate(cert_path)?;
-                                    app.users.items = user_emails;
+                                    let users = StatefulList::with_items(user_emails);
                                     match split_users_tui(
                                         &manager,
                                         terminal,
                                         &cert_path.to_string_lossy(),
-                                        &mut app.export_path,
-                                        &mut app.users,
-                                        &mut app.selected_items,
+                                        users,
                                     ) {
                                         Ok(()) => {
                                             show_input_popup(
@@ -327,14 +307,7 @@ pub fn run_app(
                             let cert_path = Path::new(&cert_path);
                             match check_certificate(cert_path) {
                                 CertificateType::Cert(_) => {
-                                    match revoke(
-                                        &manager,
-                                        terminal,
-                                        &cert_path.to_string_lossy(),
-                                        &mut app.original_pw,
-                                        &mut app.revocation_reason,
-                                        &mut app.revocation_path,
-                                    ) {
+                                    match revoke(&manager, terminal, &cert_path.to_string_lossy()) {
                                         Ok(()) => {
                                             show_input_popup(
                                                 terminal,

--- a/src/sequoia_openpgp/wrapper_fun.rs
+++ b/src/sequoia_openpgp/wrapper_fun.rs
@@ -8,10 +8,7 @@ use ratatui::{
 };
 use sequoia_openpgp::{crypto::Password, parse::Parse, Cert};
 
-use crate::{
-    app::ui::{draw_input_prompt, show_user_selection_popup},
-    widgets::list::StatefulList,
-};
+use crate::app::ui::{draw_input_prompt, show_user_selection_popup};
 
 use super::certificate_manager::CertificateManager;
 
@@ -31,14 +28,9 @@ fn validate_password(password: &str) -> Result<(), anyhow::Error> {
 pub fn generate_keypair_tui(
     cert_manager: &CertificateManager,
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
-    user_id: &mut String,
-    validity: &mut String,
-    cipher: &mut String,
-    pw: &mut String,
-    rpw: &mut String,
 ) -> Result<(), anyhow::Error> {
     let style = Style::default().fg(Color::Yellow);
-    *user_id = draw_input_prompt(
+    let user_id = draw_input_prompt(
         terminal,
         &[Line::from(Span::styled(
             "Enter user id (e.g 'Bob <Bob@domain.de>):",
@@ -84,9 +76,9 @@ pub fn generate_keypair_tui(
         .map(|line| Line::from(Span::styled(line, Style::default().fg(Color::Yellow))))
         .collect();
 
-    *validity = draw_input_prompt(terminal, &validity_spans, true)?;
-    *cipher = draw_input_prompt(terminal, &cipher_spans, true)?;
-    *pw = draw_input_prompt(
+    let validity = draw_input_prompt(terminal, &validity_spans, true)?;
+    let cipher = draw_input_prompt(terminal, &cipher_spans, true)?;
+    let pw = draw_input_prompt(
         terminal,
         &[Line::from(Span::styled(
             "Enter password (min. 8 chars, a passphrase is recommended):",
@@ -94,9 +86,9 @@ pub fn generate_keypair_tui(
         ))],
         false,
     )?;
-    validate_password(pw)?;
+    validate_password(&pw)?;
 
-    *rpw = draw_input_prompt(
+    let rpw = draw_input_prompt(
         terminal,
         &[Line::from(Span::styled("Repeat password:", style))],
         false,
@@ -106,13 +98,7 @@ pub fn generate_keypair_tui(
         return Err(anyhow::anyhow!("Passwords do not match!"));
     }
 
-    cert_manager.generate_keypair(
-        user_id.to_string(),
-        validity.to_string(),
-        cipher.to_string(),
-        pw.to_string(),
-        rpw.to_string(),
-    )?;
+    cert_manager.generate_keypair(user_id, validity, cipher, pw, rpw)?;
     Ok(())
 }
 
@@ -121,7 +107,6 @@ pub fn export_certificate_tui(
     cert_manager: &CertificateManager,
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     cert_path: &str,
-    file_name: &mut String,
 ) -> Result<(), anyhow::Error> {
     let cert = Cert::from_reader(BufReader::new(File::open(cert_path)?))?;
 
@@ -133,7 +118,7 @@ pub fn export_certificate_tui(
             draw_input_prompt(terminal, &[Line::from("Enter key secret")], false)?.into();
         match secret.decrypt_secret(&password) {
             Ok(_) => {
-                *file_name = draw_input_prompt(
+                let file_name = draw_input_prompt(
                     terminal,
                     &[Line::from(
                         "Enter exported certificate name (e.g. name.certificate.pgp):",
@@ -141,7 +126,7 @@ pub fn export_certificate_tui(
                     true,
                 )?;
 
-                cert_manager.export_certificate(cert_path, file_name)?;
+                cert_manager.export_certificate(cert_path, &file_name)?;
             }
             Err(_) => {
                 return Err(anyhow::anyhow!("Wrong password!"));
@@ -156,36 +141,34 @@ pub fn edit_password_tui(
     cert_manager: &CertificateManager,
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     certificate: &str,
-    original_pw: &mut String,
-    new_password: &mut String,
-    repeat_password: &mut String,
 ) -> Result<(), anyhow::Error> {
     let key = Cert::from_reader(BufReader::new(File::open(certificate)?))?;
     if !key.is_tsk() {
         return Err(anyhow::anyhow!("Not a secret key!"));
     } else {
         let secret = key.primary_key().key().clone().parts_into_secret()?;
-        *original_pw = draw_input_prompt(terminal, &[Line::from("Enter key secret")], false)?;
-        let original_pw = Password::from(original_pw.clone());
+        let original_pw_str =
+            draw_input_prompt(terminal, &[Line::from("Enter key secret")], false)?;
+        let original_pw = Password::from(original_pw_str);
         match secret.decrypt_secret(&original_pw) {
             Ok(_) => {
-                *new_password = draw_input_prompt(
+                let new_password = draw_input_prompt(
                     terminal,
                     &[Line::from(
                         "Enter new password (min. 8 chars, a passphrase is recommended):",
                     )],
                     false,
                 )?;
-                validate_password(new_password)?;
+                validate_password(&new_password)?;
 
-                *repeat_password =
+                let repeat_password =
                     draw_input_prompt(terminal, &[Line::from("Repeat new password")], false)?;
                 if new_password == repeat_password {
                     cert_manager.edit_password(
                         certificate,
                         &original_pw,
-                        new_password.to_string(),
-                        repeat_password.to_string(),
+                        new_password,
+                        repeat_password,
                     )?;
                 } else {
                     return Err(anyhow::anyhow!("Passwords do not match!"));
@@ -203,8 +186,6 @@ pub fn edit_expiration_time_tui(
     cert_manager: &CertificateManager,
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     certificate: &str,
-    original_pw: &mut String,
-    new_expiration_time: &mut String,
 ) -> Result<(), anyhow::Error> {
     let style = Style::default().fg(Color::Yellow);
     let prompt_validity = vec![
@@ -226,15 +207,16 @@ pub fn edit_expiration_time_tui(
         return Err(anyhow::anyhow!("Not a secret key!"));
     } else {
         let secret = key.primary_key().key().clone().parts_into_secret()?;
-        *original_pw = draw_input_prompt(terminal, &[Line::from("Enter key secret")], false)?;
-        let original_pw = Password::from(original_pw.clone());
+        let original_pw_str =
+            draw_input_prompt(terminal, &[Line::from("Enter key secret")], false)?;
+        let original_pw = Password::from(original_pw_str);
         match secret.decrypt_secret(&original_pw) {
             Ok(_) => {
-                *new_expiration_time = draw_input_prompt(terminal, &validity_spans, true)?;
+                let new_expiration_time = draw_input_prompt(terminal, &validity_spans, true)?;
                 cert_manager.edit_expiration_time(
                     certificate,
                     &original_pw,
-                    new_expiration_time.to_string(),
+                    new_expiration_time,
                 )?;
             }
             Err(_) => {
@@ -250,18 +232,16 @@ pub fn add_user_tui(
     cert_manager: &CertificateManager,
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     cert_path: &str,
-    original_pw: &mut String,
-    new_user: &mut String,
 ) -> Result<(), anyhow::Error> {
     let key = Cert::from_reader(BufReader::new(File::open(cert_path)?))?;
 
     let secret = key.primary_key().key().clone().parts_into_secret()?;
-    *original_pw = draw_input_prompt(terminal, &[Line::from("Enter key secret:")], false)?;
-    let original_pw = Password::from(original_pw.clone());
+    let original_pw_str = draw_input_prompt(terminal, &[Line::from("Enter key secret:")], false)?;
+    let original_pw = Password::from(original_pw_str);
     match secret.decrypt_secret(&original_pw) {
         Ok(_) => {
-            *new_user = draw_input_prompt(terminal, &[Line::from("Enter new user:")], true)?;
-            cert_manager.add_user(cert_path, &original_pw, new_user.to_string())?;
+            let new_user = draw_input_prompt(terminal, &[Line::from("Enter new user:")], true)?;
+            cert_manager.add_user(cert_path, &original_pw, new_user)?;
         }
         Err(_) => {
             return Err(anyhow::anyhow!("Wrong password!"));
@@ -274,19 +254,18 @@ pub fn split_users_tui(
     cert_manager: &CertificateManager,
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     cert_path: &str,
-    file_name: &mut String,
-    users: &mut StatefulList<String>,
-    selected_items: &mut Vec<bool>,
+    users: crate::widgets::list::StatefulList<String>,
 ) -> Result<(), anyhow::Error> {
+    let mut users = users;
     if users.items.is_empty() {
         return Err(anyhow::anyhow!("No users found in the certificate!"));
     }
 
-    selected_items.resize(users.items.len(), false);
-    let should_continue = show_user_selection_popup(terminal, users, selected_items)?;
+    let mut selected_items = vec![false; users.items.len()];
+    let should_continue = show_user_selection_popup(terminal, &mut users, &mut selected_items)?;
 
     if let Some(true) = should_continue {
-        *file_name = draw_input_prompt(
+        let file_name = draw_input_prompt(
             terminal,
             &[Line::from(
                 "Enter exported certificate name (e.g. name.certificate.pgp):",
@@ -307,7 +286,7 @@ pub fn split_users_tui(
             })
             .collect();
 
-        cert_manager.split_users(cert_path, file_name, selected_users.clone())?;
+        cert_manager.split_users(cert_path, &file_name, selected_users)?;
     }
 
     Ok(())
@@ -317,9 +296,6 @@ pub fn revoke(
     cert_manager: &CertificateManager,
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     certificate: &str,
-    original_pw: &mut String,
-    revocation_reason: &mut String,
-    revocation_path: &mut String,
 ) -> Result<(), anyhow::Error> {
     let style = Style::default().fg(Color::Yellow);
     let prompt_revocation_reason = vec![
@@ -337,20 +313,22 @@ pub fn revoke(
 
     let key = Cert::from_reader(BufReader::new(File::open(certificate)?))?;
     if !key.is_tsk() {
-        *revocation_path = draw_input_prompt(
+        let revocation_path = draw_input_prompt(
             terminal,
             &[Line::from("Enter revocation certificate path:")],
             true,
         )?;
-        cert_manager.revoke_certificate(certificate, revocation_path)?;
+        cert_manager.revoke_certificate(certificate, &revocation_path)?;
     } else {
         let secret = key.primary_key().key().clone().parts_into_secret()?;
-        *original_pw = draw_input_prompt(terminal, &[Line::from("Enter key secret")], false)?;
-        let original_pw = Password::from(original_pw.clone());
+        let original_pw_str =
+            draw_input_prompt(terminal, &[Line::from("Enter key secret")], false)?;
+        let original_pw = Password::from(original_pw_str);
         match secret.decrypt_secret(&original_pw) {
             Ok(_) => {
-                *revocation_reason = draw_input_prompt(terminal, &revocation_reason_spans, true)?;
-                cert_manager.revoke_key(certificate, &original_pw, revocation_reason)?
+                let revocation_reason =
+                    draw_input_prompt(terminal, &revocation_reason_spans, true)?;
+                cert_manager.revoke_key(certificate, &original_pw, &revocation_reason)?
             }
             Err(_) => {
                 return Err(anyhow::anyhow!("Wrong password!"));


### PR DESCRIPTION
## Summary

- Remove ~150 lines of dead `execute()` dispatcher, `CertificateOperation` and `CertificateOperationOutput` enums — replace with direct method calls
- Remove unused `selected_button` field from App
- Move 11 temporary TUI scratch fields (`pw`, `rpw`, `original_pw`, `uid`, `validity`, `cipher`, `export_path`, `revocation_reason`, `revocation_path`, `users`, `selected_items`) from App struct to wrapper function locals, shrinking App from 24 → 13 fields
- Add input validation: reject empty user IDs and filenames, block path traversal (`..`, `/`, `\`) in export filenames
- Replace silent cipher/revocation-reason fallbacks with explicit errors