### PR TITLE
Improvements and bug fixes

### DIFF
--- a/src/sequoia_openpgp/certificate_manager.rs
+++ b/src/sequoia_openpgp/certificate_manager.rs
@@ -319,7 +319,7 @@ impl CertificateManager {
         }
 
         match cipher.as_str() {
-            "1" => builder = builder.set_cipher_suite(CipherSuite::Cv25519),
+            "1" | "" => builder = builder.set_cipher_suite(CipherSuite::Cv25519),
             "2" => builder = builder.set_cipher_suite(CipherSuite::RSA2k),
             "3" => builder = builder.set_cipher_suite(CipherSuite::RSA3k),
             "4" => builder = builder.set_cipher_suite(CipherSuite::RSA4k),

--- a/src/sequoia_openpgp/certificate_manager.rs
+++ b/src/sequoia_openpgp/certificate_manager.rs
@@ -20,6 +20,12 @@ use crate::app::launch::clear_screen;
 use crate::utils::create_directory::{create_file, create_secret_file};
 use crate::utils::parse_iso8601_duration::parse_iso8601_duration;
 
+/// Sanitize a user ID for use as a filename component.
+/// Replaces `..`, `/`, and `\` with `_` to prevent path traversal.
+fn sanitize_for_path(input: &str) -> String {
+    input.replace("..", "_").replace(['/', '\\'], "_")
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct CertificateManager;
 
@@ -294,7 +300,7 @@ impl CertificateManager {
         clear_screen();
         let mut builder = CertBuilder::new();
 
-        let uid_clone = user_id.clone();
+        let safe_uid = sanitize_for_path(&user_id);
         builder = builder.add_userid(user_id);
 
         match validity.as_str() {
@@ -352,11 +358,11 @@ impl CertificateManager {
         let home_dir = home::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
         let key_path =
-            format!("{}/.pgpman/secrets/{}.pgp", &home_dir.display(), uid_clone).replace(" ", "");
+            format!("{}/.pgpman/secrets/{}.pgp", &home_dir.display(), safe_uid).replace(" ", "");
         let revcert_path = format!(
             "{}/.pgpman/revocation/{}.rev",
             &home_dir.display(),
-            uid_clone
+            safe_uid
         )
         .replace(" ", "");
         // export key to path
@@ -381,7 +387,7 @@ impl CertificateManager {
         let cert_path = format!(
             "{}/.pgpman/certificates/{}.pgp",
             &home_dir.display(),
-            uid_clone
+            safe_uid
         )
         .replace(" ", "");
         {


### PR DESCRIPTION
## Summary

- **Input retry loops**: Validation failures (empty user ID, short password, mismatched passwords, invalid filename) now show an error popup and re-prompt instead of aborting the entire TUI flow
- **Default cipher selection**: Empty cipher input defaults to Cv25519, matching how validity already defaults to 2 years
- **User ID path sanitization (Issue #36)**: `generate_keypair` now sanitizes `../`, `/`, and `\` in User IDs before constructing file paths, preventing writes outside `~/.pgpman/`

Closes #36