### PR TITLE
Fix underflow bugs, silent error, dead code, and path sanitization

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -5,7 +5,6 @@ use crate::widgets::list::StatefulList;
 pub struct App {
     pub items: StatefulList<String>,
     pub key_details: Option<String>,
-    pub popup: bool,
     pub scroll_state: usize,
     pub current_dir: PathBuf,
     pub help_items: StatefulList<String>,
@@ -54,13 +53,12 @@ impl App {
         );
         help_descriptions.insert(
             "- Esc: Go up a directory".to_string(),
-            "Go up a directory\nNote: it will be able in a future update to abort from an operation".to_string(),
+            "Go up a directory\nNote: it will be available in a future update to abort from an operation".to_string(),
         );
 
         App {
             items: StatefulList::with_items(items),
             key_details: None,
-            popup: false,
             scroll_state: 0,
             current_dir,
             help_items: StatefulList::with_items(vec![

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -386,8 +386,8 @@ pub fn run_app(
                     KeyCode::Left => app.items.unselect(),
                     KeyCode::Down => {
                         if let Some(details) = &app.key_details {
-                            app.scroll_state =
-                                (app.scroll_state + 1).min(details.lines().count() - 1);
+                            app.scroll_state = (app.scroll_state + 1)
+                                .min(details.lines().count().saturating_sub(1));
                         } else {
                             app.items.next();
                         }

--- a/src/sequoia_openpgp/certificate_manager.rs
+++ b/src/sequoia_openpgp/certificate_manager.rs
@@ -23,7 +23,7 @@ use crate::utils::parse_iso8601_duration::parse_iso8601_duration;
 /// Sanitize a user ID for use as a filename component.
 /// Replaces `..`, `/`, and `\` with `_` to prevent path traversal.
 fn sanitize_for_path(input: &str) -> String {
-    input.replace("..", "_").replace(['/', '\\'], "_")
+    input.replace("..", "_").replace(['/', '\\', ' '], "_")
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -357,14 +357,12 @@ impl CertificateManager {
         // Note: certificate on the context of the sequoia openpgp crate means the public key that can be shared
         let home_dir = home::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-        let key_path =
-            format!("{}/.pgpman/secrets/{}.pgp", &home_dir.display(), safe_uid).replace(" ", "");
+        let key_path = format!("{}/.pgpman/secrets/{}.pgp", &home_dir.display(), safe_uid);
         let revcert_path = format!(
             "{}/.pgpman/revocation/{}.rev",
             &home_dir.display(),
             safe_uid
-        )
-        .replace(" ", "");
+        );
         // export key to path
         {
             if let Some(w) = create_secret_file(Some(key_path.as_str()))? {
@@ -388,8 +386,7 @@ impl CertificateManager {
             "{}/.pgpman/certificates/{}.pgp",
             &home_dir.display(),
             safe_uid
-        )
-        .replace(" ", "");
+        );
         {
             if let Some(mut w) = create_file(Some(cert_path.as_str()))? {
                 key.strip_secret_key_material()

--- a/src/sequoia_openpgp/certificate_manager.rs
+++ b/src/sequoia_openpgp/certificate_manager.rs
@@ -449,6 +449,8 @@ impl CertificateManager {
             if let Some(mut out) = create_secret_file(Some(secret_key))? {
                 key.as_tsk().armored().serialize(&mut out)?;
             }
+        } else {
+            return Err(anyhow::anyhow!("Passwords do not match!"));
         }
         Ok(())
     }

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -28,6 +28,9 @@ impl<T> StatefulList<T> {
 
     /// Selects the next item.
     pub fn next(&mut self) {
+        if self.items.is_empty() {
+            return;
+        }
         let i = match self.state.selected() {
             Some(i) => {
                 if i >= self.items.len() - 1 {
@@ -43,6 +46,9 @@ impl<T> StatefulList<T> {
 
     /// Selects the previous item.
     pub fn previous(&mut self) {
+        if self.items.is_empty() {
+            return;
+        }
         let i = match self.state.selected() {
             Some(i) => {
                 if i == 0 {

--- a/tests/certificate_manager.rs
+++ b/tests/certificate_manager.rs
@@ -15,7 +15,7 @@ fn manager() -> CertificateManager {
 
 /// Mirror the sanitization logic from `certificate_manager::sanitize_for_path`.
 fn sanitize_for_path(input: &str) -> String {
-    input.replace("..", "_").replace(['/', '\\'], "_")
+    input.replace("..", "_").replace(['/', '\\', ' '], "_")
 }
 
 /// Helper to compute the paths that `generate_keypair` writes to in ~/.pgpman/.
@@ -23,9 +23,9 @@ fn pgpman_paths(uid: &str) -> (String, String, String) {
     let home = home::home_dir().unwrap();
     let safe = sanitize_for_path(uid);
     (
-        format!("{}/.pgpman/secrets/{}.pgp", home.display(), safe).replace(' ', ""),
-        format!("{}/.pgpman/revocation/{}.rev", home.display(), safe).replace(' ', ""),
-        format!("{}/.pgpman/certificates/{}.pgp", home.display(), safe).replace(' ', ""),
+        format!("{}/.pgpman/secrets/{}.pgp", home.display(), safe),
+        format!("{}/.pgpman/revocation/{}.rev", home.display(), safe),
+        format!("{}/.pgpman/certificates/{}.pgp", home.display(), safe),
     )
 }
 


### PR DESCRIPTION
## Summary

- **Fix arithmetic underflow bugs**: Use `saturating_sub(1)` for scroll state when details are empty, and add early returns in `next()`/`previous()` for empty lists to prevent panics
- **Fix silent success on mismatched passwords**: `edit_password` now returns an error when new passwords don't match instead of silently succeeding
- **Remove dead `popup` field and fix typo**: Remove unused `popup: bool` from `App`, fix "it will be able" → "it will be available" in help text
- **Integrate space removal into `sanitize_for_path`**: Move space replacement into the helper so callers don't need a separate `.replace(" ", "")` step